### PR TITLE
Add Entity Names for Tests where they are missing

### DIFF
--- a/squash-core/test/org/jetbrains/squash/tests/DefinitionTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/DefinitionTests.kt
@@ -17,7 +17,7 @@ abstract class DefinitionTests : DatabaseTests {
     }
 
     @Test fun tableExists() {
-        val TestTable = object : TableDefinition() {
+		val TestTable = object : TableDefinition("Test") {
             val id = integer("id").primaryKey()
             val name = varchar("name", length = 42)
         }
@@ -28,7 +28,7 @@ abstract class DefinitionTests : DatabaseTests {
     }
 
     @Test fun unnamedTableWithQuotesSQL() {
-        val TestTable = object : TableDefinition() {
+		val TestTable = object : TableDefinition("unnamedTableWithQuotesSQL\$TestTable\$1") {
             val id = integer("id").primaryKey()
             val name = varchar("name", length = 42)
         }


### PR DESCRIPTION
Fixes Item 1 from issue #12 

The squash API requires names for entities, which makes sense, but some tests do not provide a name in the constructor, causing a runtime failure.

I have added names to the two tests that were failing as a result.

See:
https://github.com/orangy/squash/blob/83c9b4f057d7ba9380688e9315f9a39244798b96/squash-core/src/org/jetbrains/squash/definition/Name.kt#L11