### PR TITLE
Updated MySQL Embed

### DIFF
--- a/squash-mysql/pom.xml
+++ b/squash-mysql/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.wix</groupId>
             <artifactId>wix-embedded-mysql</artifactId>
-            <version>2.1.4</version>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Fixes Item 2 of Issue #12 
Updating mysql embed library to remove an issue where mysql tests cannot be run on windows (Process is unable to open the windows event log), causing all mysql tests to fail.