### PR TITLE
Cleanup Deprecated Calls to Class.newInstance()

### DIFF
--- a/squash-h2/src/org/jetbrains/squash/dialects/h2/H2Connection.kt
+++ b/squash-h2/src/org/jetbrains/squash/dialects/h2/H2Connection.kt
@@ -11,7 +11,7 @@ class H2Connection(connector: () -> Connection) : JDBCConnection(H2Dialect, H2Da
     companion object {
         fun create(url: String, user: String = "", password: String = ""): DatabaseConnection {
             require(url.startsWith("jdbc:h2:")) { "H2 JDBC connection requires 'jdbc:h2:' prefix" }
-            Class.forName("org.h2.Driver").newInstance()
+            Class.forName("org.h2.Driver").getConstructor().newInstance()
             return H2Connection { DriverManager.getConnection(url, user, password) }
         }
 

--- a/squash-jdbc/src/org/jetbrains/squash/drivers/JDBCConnection.kt
+++ b/squash-jdbc/src/org/jetbrains/squash/drivers/JDBCConnection.kt
@@ -15,7 +15,7 @@ open class JDBCConnection(override val dialect: SQLDialect, val conversion: JDBC
 
     companion object {
         fun create(dialect: SQLDialect, url: String, driver: String, user: String = "", password: String = ""): DatabaseConnection {
-            Class.forName(driver).newInstance()
+            Class.forName(driver).getConstructor().newInstance()
             return JDBCConnection(dialect, JDBCDataConversion()) {
                 DriverManager.getConnection(url, user, password)
             }

--- a/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlConnection.kt
+++ b/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlConnection.kt
@@ -10,7 +10,7 @@ class MySqlConnection(connector: () -> Connection) : JDBCConnection(MySqlDialect
     companion object {
         fun create(url: String, user: String = "", password: String = ""): DatabaseConnection {
             require(url.startsWith("jdbc:mysql:")) { "MySQL JDBC connection requires 'jdbc:mysql:' prefix" }
-            Class.forName("com.mysql.cj.jdbc.Driver").newInstance()
+            Class.forName("com.mysql.cj.jdbc.Driver").getConstructor().newInstance()
             return MySqlConnection { DriverManager.getConnection(url, user, password) }
         }
     }

--- a/squash-postgres/src/org/jetbrains/squash/dialects/postgres/PgConnection.kt
+++ b/squash-postgres/src/org/jetbrains/squash/dialects/postgres/PgConnection.kt
@@ -8,7 +8,7 @@ class PgConnection(connector: () -> Connection) : JDBCConnection(PgDialect, PgDa
     override fun createTransaction() = PgTransaction(this)
 
     companion object {
-        private val driver = Class.forName("org.postgresql.Driver").newInstance()
+        private val driver = Class.forName("org.postgresql.Driver").getConstructor().newInstance()
 
         fun create(host: String, user: String = "", password: String = ""): DatabaseConnection {
             val jdbcUrl = "jdbc:postgresql://$host"

--- a/squash-sqlite/src/org/jetbrains/squash/dialects/sqlite/SqLiteConnection.kt
+++ b/squash-sqlite/src/org/jetbrains/squash/dialects/sqlite/SqLiteConnection.kt
@@ -9,13 +9,13 @@ class SqLiteConnection(connector: () -> Connection) : JDBCConnection(SqLiteDiale
 
     companion object {
         fun create(url: String, user: String = "", password: String = ""): JDBCConnection {
-            Class.forName("org.sqlite.JDBC").newInstance()
+            Class.forName("org.sqlite.JDBC").getConstructor().newInstance()
             val jdbcUrl = "jdbc:sqlite://$url"
             return SqLiteConnection { DriverManager.getConnection(jdbcUrl, user, password) }
         }
 
         fun createMemoryConnection(user: String = "", password: String = ""): JDBCConnection {
-            Class.forName("org.sqlite.JDBC").newInstance()
+            Class.forName("org.sqlite.JDBC").getConstructor().newInstance()
             val jdbcUrl = "jdbc:sqlite:file:memdb1?mode=memory&cache=shared"
             return SqLiteConnection { DriverManager.getConnection(jdbcUrl, user, password) }
         }


### PR DESCRIPTION
In an effort to cleanup the deprecation warnings, we replaced calls to Class.newInstance() with Class.getConstructor().newInstance()