### PR TITLE
SQL 92 Case Expression Support

### DIFF
--- a/squash-core/src/org/jetbrains/squash/expressions/CaseExpression.kt
+++ b/squash-core/src/org/jetbrains/squash/expressions/CaseExpression.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.squash.expressions
+
+class CaseExpression<T>(val target:Expression<*>? = null) : Expression<T> {
+	val clauses = mutableListOf<WhenThenClause<T>>()
+	var finalClause:Expression<T>? = null
+
+	fun whenClause(expression:Expression<*>):WhenThenClause<T> = WhenThenClause(this, expression).apply {
+		this@CaseExpression.clauses.add(this)
+	}
+
+	fun elseClause(expression:Expression<T>):CaseExpression<T> = this.apply {
+		finalClause = expression
+	}
+
+	class WhenThenClause<T>(
+			val caseExpression:CaseExpression<T>,
+			val whenClause:Expression<*>
+	) {
+		lateinit var thenClause:Expression<T>
+		
+		fun thenClause(expression:Expression<T>):CaseExpression<T> {
+			thenClause = expression
+			return caseExpression
+		}
+	}
+}
+
+inline fun <T> case(target:Expression<*>? = null, clauses:CaseExpression<T>.() -> Unit) = CaseExpression<T>(target).apply(clauses)

--- a/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
@@ -3,8 +3,9 @@ package org.jetbrains.squash.tests
 import org.jetbrains.squash.definition.*
 import org.jetbrains.squash.expressions.*
 import org.jetbrains.squash.query.*
-import org.jetbrains.squash.results.*
-import org.jetbrains.squash.statements.*
+import org.jetbrains.squash.results.get
+import org.jetbrains.squash.statements.insertInto
+import org.jetbrains.squash.statements.values
 import org.jetbrains.squash.tests.data.*
 import kotlin.test.*
 
@@ -12,7 +13,7 @@ abstract class QueryTests : DatabaseTests {
     open fun nullsLast(sql: String): String = "$sql NULLS LAST"
 
     @Test fun selectLiteral() {
-        withTables() {
+        withTables {
             val eugene = literal("eugene")
             val query = select { eugene }
 
@@ -447,7 +448,45 @@ abstract class QueryTests : DatabaseTests {
 
         }
     }
+	
+	@Test fun selectCaseStatementTrue() {
+		withTables {
+			val query = select(
+				case<Boolean>(literal(5)) {
+					whenClause(literal(6)).thenClause(literal(false))
+					whenClause(literal(5)).thenClause(literal(true))
+					whenClause(literal(4)).thenClause(literal(false))
+					elseClause(literal(false))
+			})
 
+			connection.dialect.statementSQL(query).assertSQL {
+				"SELECT CASE (?) WHEN (?) THEN ? WHEN (?) THEN ? WHEN (?) THEN ? ELSE ? END"
+			}
+			
+			val result = query.execute().single().get<Long>(0)
+			assertEquals(result, 1L)
+		}
+	}
+
+	@Test fun selectCaseStatementFalse() {
+		withTables {
+			val query = select(
+					case<Boolean>(literal(-1)) {
+						whenClause(literal(6)).thenClause(literal(false))
+						whenClause(literal(5)).thenClause(literal(true))
+						whenClause(literal(4)).thenClause(literal(false))
+						elseClause(literal(false))
+					})
+
+			connection.dialect.statementSQL(query).assertSQL {
+				"SELECT CASE (?) WHEN (?) THEN ? WHEN (?) THEN ? WHEN (?) THEN ? ELSE ? END"
+			}
+
+			val result = query.execute().single().get<Long>(0)
+			assertEquals(result, 0L)
+		}
+	}
+	
     @Test fun selectFromNestedQuery() {
         withCities {
             val query = from(select(Citizens.name, Citizens.id).from(Citizens).alias("Citizens"))

--- a/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
@@ -452,38 +452,36 @@ abstract class QueryTests : DatabaseTests {
 	@Test fun selectCaseStatementTrue() {
 		withTables {
 			val query = select(
-				case<Boolean>(literal(5)) {
-					whenClause(literal(6)).thenClause(literal(false))
-					whenClause(literal(5)).thenClause(literal(true))
-					whenClause(literal(4)).thenClause(literal(false))
-					elseClause(literal(false))
+				case<String>(literal(5)) {
+					whenClause(literal(6)).thenClause(literal("false"))
+					whenClause(literal(5)).thenClause(literal("true"))
+					whenClause(literal(4)).thenClause(literal("false"))
+					elseClause(literal("false"))
 			})
 
 			connection.dialect.statementSQL(query).assertSQL {
 				"SELECT CASE (?) WHEN (?) THEN ? WHEN (?) THEN ? WHEN (?) THEN ? ELSE ? END"
 			}
-			
-			val result = query.execute().single().get<Long>(0)
-			assertEquals(result, 1L)
+
+			assertTrue { query.execute().single().get<String>(0).toBoolean() }
 		}
 	}
 
 	@Test fun selectCaseStatementFalse() {
 		withTables {
 			val query = select(
-					case<Boolean>(literal(-1)) {
-						whenClause(literal(6)).thenClause(literal(false))
-						whenClause(literal(5)).thenClause(literal(true))
-						whenClause(literal(4)).thenClause(literal(false))
-						elseClause(literal(false))
+					case<String>(literal(-1)) {
+						whenClause(literal(6)).thenClause(literal("false"))
+						whenClause(literal(5)).thenClause(literal("true"))
+						whenClause(literal(4)).thenClause(literal("false"))
+						elseClause(literal("false"))
 					})
 
 			connection.dialect.statementSQL(query).assertSQL {
 				"SELECT CASE (?) WHEN (?) THEN ? WHEN (?) THEN ? WHEN (?) THEN ? ELSE ? END"
 			}
 
-			val result = query.execute().single().get<Long>(0)
-			assertEquals(result, 0L)
+			assertFalse { query.execute().single().get<String>(0).toBoolean() }
 		}
 	}
 	


### PR DESCRIPTION
## Description
Adds common support for the SQL 92 case expression. Expressions of both common formats are supported.

## Supported SQL
### CASE With Primary Operand / Condition
SQL:
```sql
CASE (yesOrNo)
WHEN ('yes') THEN 1
ELSE 0
END
```

### CASE Without Primary Operand / Condition
```sql
CASE
WHEN (yesOrNo = 'yes') THEN 1
WHEN (yesOrNo = 'no') THEN 0
ELSE -1
END
```
## Kotlin Example
Taken from unit tests.
```kotlin
/*
 * Note the use of the word "Clause" to avoid reserved words.
 */
select(
	case<String>(literal(5)) {
		whenClause(literal(6)).thenClause(literal("false"))
		whenClause(literal(5)).thenClause(literal("true"))
		whenClause(literal(4)).thenClause(literal("false"))
		elseClause(literal("false"))
	}
)
```

## Testing
A basic test case was added for this functionality, but could be improved to include more varying conditions, though this may not be necessary because it is ultimately using `Expression<*>`s for most functionality related to the conditions and values.

> Edited to include a kotlin example from unit tests