### PR TITLE
 MySQL Dialect : Support Basic Date Part and Date Math Functions

### DIFF
--- a/squash-core/src/org/jetbrains/squash/dialect/BaseSQLDialect.kt
+++ b/squash-core/src/org/jetbrains/squash/dialect/BaseSQLDialect.kt
@@ -145,12 +145,12 @@ open class BaseSQLDialect(val name: String) : SQLDialect {
         when (expression) {
             is CountExpression -> {
                 append("COUNT(")
-                appendExpression(this, expression.value)
+                appendExpression(this, expression.value!!)
                 append(")")
             }
             is CountDistinctExpression -> {
                 append("COUNT(DISTINCT ")
-                appendExpression(this, expression.value)
+                appendExpression(this, expression.value!!)
                 append(")")
             }
 			is GeneralFunctionExpression -> {

--- a/squash-core/src/org/jetbrains/squash/dialect/BaseSQLDialect.kt
+++ b/squash-core/src/org/jetbrains/squash/dialect/BaseSQLDialect.kt
@@ -153,21 +153,11 @@ open class BaseSQLDialect(val name: String) : SQLDialect {
                 appendExpression(this, expression.value)
                 append(")")
             }
-            is MaxExpression -> {
-                append("MAX(")
-                appendExpression(this, expression.value)
-                append(")")
-            }
-            is MinExpression -> {
-                append("MIN(")
-                appendExpression(this, expression.value)
-                append(")")
-            }
-            is SumExpression -> {
-                append("SUM(")
-                appendExpression(this, expression.value)
-                append(")")
-            }
+			is GeneralFunctionExpression -> {
+				append("${expression.name}(")
+				appendExpression(this, expression.value)
+				append(")")
+			}
             else -> error("Function '$expression' is not supported by ${this@BaseSQLDialect}")
         }
     }

--- a/squash-core/src/org/jetbrains/squash/expressions/FunctionExpression.kt
+++ b/squash-core/src/org/jetbrains/squash/expressions/FunctionExpression.kt
@@ -17,7 +17,7 @@ class CountDistinctExpression(val value:Expression<*>? = null) : FunctionExpress
 
 fun Expression<*>.count() = CountExpression(this)
 fun Expression<*>.countDistinct() = CountDistinctExpression(this)
-fun Expression<*>.min() = GeneralFunctionExpression<Long>("MIN",this)
-fun Expression<*>.max() = GeneralFunctionExpression<Long>("MAX", this)
-fun Expression<*>.sum() = GeneralFunctionExpression<Long>("SUM",this)
+fun <T> Expression<T>.min() = GeneralFunctionExpression<T>("MIN",this)
+fun <T> Expression<T>.max() = GeneralFunctionExpression<T>("MAX", this)
+fun <T> Expression<T>.sum() = GeneralFunctionExpression<T>("SUM",this)
 fun Expression<*>.average() = GeneralFunctionExpression<BigDecimal>("AVG",this)

--- a/squash-core/src/org/jetbrains/squash/expressions/FunctionExpression.kt
+++ b/squash-core/src/org/jetbrains/squash/expressions/FunctionExpression.kt
@@ -1,16 +1,23 @@
 package org.jetbrains.squash.expressions
 
+import java.math.BigDecimal
+
 interface FunctionExpression<out R> : Expression<R>
 
-class CountExpression(val value: Expression<*>) : FunctionExpression<Long>
-class CountDistinctExpression(val value: Expression<*>) : FunctionExpression<Long>
-class MinExpression(val value: Expression<*>) : FunctionExpression<Long>
-class MaxExpression(val value: Expression<*>) : FunctionExpression<Long>
-class SumExpression(val value: Expression<*>) : FunctionExpression<Long>
+/**
+ * Represents any function with a name, single argument, and return value.
+ */
+class GeneralFunctionExpression<T>(
+		val name:String,
+		val value:Expression<*>
+) : FunctionExpression<T>
+
+class CountExpression(val value: Expression<*>? = null) : FunctionExpression<Long>
+class CountDistinctExpression(val value:Expression<*>? = null) : FunctionExpression<Long>
 
 fun Expression<*>.count() = CountExpression(this)
 fun Expression<*>.countDistinct() = CountDistinctExpression(this)
-fun Expression<*>.min() = MinExpression(this)
-fun Expression<*>.max() = MaxExpression(this)
-fun Expression<*>.sum() = SumExpression(this)
-
+fun Expression<*>.min() = GeneralFunctionExpression<Long>("MIN",this)
+fun Expression<*>.max() = GeneralFunctionExpression<Long>("MAX", this)
+fun Expression<*>.sum() = GeneralFunctionExpression<Long>("SUM",this)
+fun Expression<*>.average() = GeneralFunctionExpression<BigDecimal>("AVG",this)

--- a/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
@@ -7,6 +7,7 @@ import org.jetbrains.squash.results.*
 import org.jetbrains.squash.statements.*
 import org.jetbrains.squash.tests.data.*
 import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.test.*
 
 abstract class QueryTests : DatabaseTests {
@@ -462,13 +463,10 @@ abstract class QueryTests : DatabaseTests {
 					.and(CityStats.name eq "population")
 				)
 			
-			println(connection.dialect.statementSQL(query))
-			
 			val result = query.execute().single()
-			assertEquals(1500000, result["minimum"], "Minimum city population does not match")
-			assertEquals(6200000, result["maximum"], "Maximum city population does not match")
-			assertEquals(BigDecimal("3433333.3333"), result["average"], "Average city population does not match")
-
+			assertEquals(BigDecimal("1500000"), result["minimum"], "Minimum city population does not match")
+			assertEquals(BigDecimal("6200000"), result["maximum"], "Maximum city population does not match")
+			assertEquals(BigInteger("3433333"), result.get<BigDecimal>("average").toBigInteger(), "Average city population does not match")
 		}
 	}
 	

--- a/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
@@ -449,8 +449,7 @@ abstract class QueryTests : DatabaseTests {
         }
     }
 
-	@Test
-	fun selectAggregate() {
+	@Test fun selectAggregate() {
 		withCities {
 			val query = select(
 					CityStats.value.min().alias("minimum"),
@@ -469,23 +468,7 @@ abstract class QueryTests : DatabaseTests {
 			assertEquals(1500000, result["minimum"], "Minimum city population does not match")
 			assertEquals(6200000, result["maximum"], "Maximum city population does not match")
 			assertEquals(BigDecimal("3433333.3333"), result["average"], "Average city population does not match")
-/*
-			connection.dialect.statementSQL(query).assertSQL {
-				"SELECT Cities.name, COUNT(Citizens.id) AS citizens FROM Cities INNER JOIN Citizens ON Cities.id = Citizens.city_id GROUP BY Cities.name"
-			}
 
-			query.execute().forEach {
-				val cityName = it[Cities.name]
-				val userCount = it.get<Long>("citizens")
-
-				when (cityName) {
-					"Munich" -> assertEquals(2, userCount)
-					"Prague" -> assertEquals(0, userCount)
-					"St. Petersburg" -> assertEquals(1, userCount)
-					else -> error("Unknown city $cityName")
-				}
-			}
- */
 		}
 	}
 	

--- a/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/QueryTests.kt
@@ -6,6 +6,7 @@ import org.jetbrains.squash.query.*
 import org.jetbrains.squash.results.*
 import org.jetbrains.squash.statements.*
 import org.jetbrains.squash.tests.data.*
+import java.math.BigDecimal
 import kotlin.test.*
 
 abstract class QueryTests : DatabaseTests {
@@ -448,6 +449,46 @@ abstract class QueryTests : DatabaseTests {
         }
     }
 
+	@Test
+	fun selectAggregate() {
+		withCities {
+			val query = select(
+					CityStats.value.min().alias("minimum"),
+					CityStats.value.max().alias("maximum"),
+					CityStats.value.average().alias("average")
+				)
+				.from(Cities)
+				.innerJoin(CityStats, 
+					(Cities.id eq CityStats.cityId)
+					.and(CityStats.name eq "population")
+				)
+			
+			println(connection.dialect.statementSQL(query))
+			
+			val result = query.execute().single()
+			assertEquals(1500000, result["minimum"], "Minimum city population does not match")
+			assertEquals(6200000, result["maximum"], "Maximum city population does not match")
+			assertEquals(BigDecimal("3433333.3333"), result["average"], "Average city population does not match")
+/*
+			connection.dialect.statementSQL(query).assertSQL {
+				"SELECT Cities.name, COUNT(Citizens.id) AS citizens FROM Cities INNER JOIN Citizens ON Cities.id = Citizens.city_id GROUP BY Cities.name"
+			}
+
+			query.execute().forEach {
+				val cityName = it[Cities.name]
+				val userCount = it.get<Long>("citizens")
+
+				when (cityName) {
+					"Munich" -> assertEquals(2, userCount)
+					"Prague" -> assertEquals(0, userCount)
+					"St. Petersburg" -> assertEquals(1, userCount)
+					else -> error("Unknown city $cityName")
+				}
+			}
+ */
+		}
+	}
+	
     @Test fun selectFromNestedQuery() {
         withCities {
             val query = from(select(Citizens.name, Citizens.id).from(Citizens).alias("Citizens"))

--- a/squash-core/test/org/jetbrains/squash/tests/data/AllColumnTypes.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/data/AllColumnTypes.kt
@@ -1,6 +1,16 @@
 package org.jetbrains.squash.tests.data
 
+import org.jetbrains.squash.connection.BinaryObject
+import org.jetbrains.squash.connection.Transaction
 import org.jetbrains.squash.definition.*
+import org.jetbrains.squash.statements.insertInto
+import org.jetbrains.squash.statements.values
+import org.jetbrains.squash.tests.DatabaseTests
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.*
 
 enum class E {
     ONE,
@@ -22,4 +32,25 @@ object AllColumnTypes : TableDefinition() {
     val binary = binary("binary", 128)
     val blob = blob("blob")
     val uuid = uuid("uuid")
+}
+
+fun <R> DatabaseTests.withAllColumnTypes(statement:Transaction.() -> R) :R {
+	return withTables(AllColumnTypes) {
+		insertInto(AllColumnTypes).values {
+			it[varchar] = "varchar"
+			it[char] = "c"
+			it[enum] = E.ONE
+			it[decimal] = BigDecimal.ONE
+			it[long] = 222L
+			it[date] = LocalDate.of(1976, 11, 24)
+			it[bool] = true
+			it[datetime] = LocalDateTime.of(LocalDate.of(1976, 11, 24), LocalTime.of(8, 22))
+			it[text] = "Lorem Ipsum"
+			it[binary] = byteArrayOf(1, 2, 3)
+			it[blob] = BinaryObject.fromByteArray(this@withTables, byteArrayOf(1, 2, 3))
+			it[uuid] = UUID.fromString("7cb64fe4-4938-4e88-8d94-17e929d40c99")
+		}.execute()
+		
+		statement()
+	}
 }

--- a/squash-core/test/org/jetbrains/squash/tests/data/CitiesData.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/data/CitiesData.kt
@@ -7,7 +7,7 @@ import org.jetbrains.squash.statements.*
 import org.jetbrains.squash.tests.*
 
 fun <R> DatabaseTests.withCities(statement: Transaction.() -> R) :R {
-    return withTables(Cities, CitizenData, Citizens, CitizenDataLink) {
+    return withTables(Cities, CityStats, CitizenData, Citizens, CitizenDataLink) {
         val spbId = insertInto(Cities).values {
             it[name] = "St. Petersburg"
         }.fetch(Cities.id).execute()
@@ -16,10 +16,35 @@ fun <R> DatabaseTests.withCities(statement: Transaction.() -> R) :R {
             it[name] = "Munich"
         }.fetch(Cities.id).execute()
 
-        insertInto(Cities).values {
+        val pragueId = insertInto(Cities).values {
             it[name] = "Prague"
-        }.execute()
+        }.fetch(Cities.id).execute()
+		
+		/*
+		 * Insert City Statistics
+		 */
 
+		insertInto(CityStats).values {
+			it[cityId] = spbId
+			it[name] = "population"
+			it[value] = 6200000
+		}.execute()
+		
+		insertInto(CityStats).values { 
+			it[cityId] = munichId
+			it[name] = "population"
+			it[value] = 1500000
+		}.execute()
+
+		insertInto(CityStats).values {
+			it[cityId] = pragueId
+			it[name] = "population"
+			it[value] = 2600000
+		}.execute()
+
+		/*
+		 * Insert Citizens
+		 */
         insertInto(Citizens).query()
                 .select { literal("andrey").alias("id") }
                 .select { literal("Andrey").alias("name") }

--- a/squash-core/test/org/jetbrains/squash/tests/data/CitiesSchema.kt
+++ b/squash-core/test/org/jetbrains/squash/tests/data/CitiesSchema.kt
@@ -10,6 +10,12 @@ object Cities : TableDefinition() {
     val name = varchar("name", 50)
 }
 
+object CityStats : TableDefinition() {
+	val cityId = reference(Cities.id, "cityId")
+	val name = varchar("name", 50)
+	val value = long("value")
+}
+
 object Citizens : TableDefinition() {
     val id = varchar("id", 10).primaryKey()
     val name = varchar("name", length = 50)

--- a/squash-jdbc/src/org/jetbrains/squash/drivers/JDBCDataConversion.kt
+++ b/squash-jdbc/src/org/jetbrains/squash/drivers/JDBCDataConversion.kt
@@ -1,7 +1,8 @@
 package org.jetbrains.squash.drivers
 
 import org.jetbrains.squash.connection.*
-import java.math.*
+import java.math.BigDecimal
+import java.math.BigInteger
 import java.sql.*
 import java.time.*
 import kotlin.reflect.*
@@ -30,11 +31,16 @@ open class JDBCDataConversion {
             value is Time -> value.toLocalTime()
             value is Blob -> JDBCBinaryObject(value.getBytes(1, value.length().toInt()))
             value is ByteArray && type == BinaryObject::class -> JDBCBinaryObject(value)
-            type.javaObjectType.isInstance(value) -> value
+			value is Double && type.javaObjectType == BigDecimal::class.java -> value.toBigDecimal()
+			value is Int && type.javaObjectType == BigInteger::class.java -> value.toBigInteger()
+			value is Int && type.javaObjectType == BigDecimal::class.java -> value.toBigDecimal()
             value is Long && type.javaObjectType == Int::class.javaObjectType -> value.toInt()
+			value is Long && type.javaObjectType == BigInteger::class.java -> value.toBigInteger()
+			value is Long && type.javaObjectType == BigDecimal::class.java -> value.toBigDecimal()
             value is Int && type.javaObjectType == Long::class.javaObjectType -> value.toLong()
             value is BigInteger && type.javaObjectType == Int::class.javaObjectType -> value.toInt()
             value is BigInteger && type.javaObjectType == Long::class.javaObjectType -> value.toLong()
+			type.javaObjectType.isInstance(value) -> value
             else -> error("Cannot convert value of type `${value.javaClass}` to type `$type`")
         }
     }

--- a/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlDefinitionSQLDialect.kt
+++ b/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlDefinitionSQLDialect.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.squash.dialects.mysql
+
+import org.jetbrains.squash.dialect.BaseDefinitionSQLDialect
+
+class MySqlDefinitionSQLDialect : BaseDefinitionSQLDialect(MySqlDialect)

--- a/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlDialect.kt
+++ b/squash-mysql/src/org/jetbrains/squash/dialects/mysql/MySqlDialect.kt
@@ -40,7 +40,7 @@ object MySqlDialect : BaseSQLDialect("MySQL") {
 				append("${expression.name}(")
 				appendExpression(this, expression.expression)
 				append(", INTERVAL ")
-				appendExpression(this, literal(expression.interval.value))
+				appendExpression(this, expression.interval.value)
 				append(" ${expression.interval.unit})")
 			}
 			else -> super.appendFunctionExpression(builder, expression)

--- a/squash-mysql/src/org/jetbrains/squash/dialects/mysql/expressions/DateExpressions.kt
+++ b/squash-mysql/src/org/jetbrains/squash/dialects/mysql/expressions/DateExpressions.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.squash.dialects.mysql.expressions
+
+import org.jetbrains.squash.dialects.mysql.expressions.MysqlTimeUnit.Companion.from
+import org.jetbrains.squash.expressions.Expression
+import org.jetbrains.squash.expressions.FunctionExpression
+import org.jetbrains.squash.expressions.GeneralFunctionExpression
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+/**
+ *  Extract the date part of a date or datetime expression
+ */
+fun Expression<*>.date() = GeneralFunctionExpression<LocalDate>("DATE", this)
+
+/**
+ *  Subtract a time value (using Java [ChronoUnit]) from a date
+ */
+fun Expression<*>.dateSub(value:Long, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_SUB", this, from(value, timeUnit))
+
+/**
+ * Subtracts a number of days from a date.
+ */
+fun Expression<*>.dateSub(days:Long) = MysqlDateMathFunction("DATE_SUB", this, MysqlTimeUnit(days, "DAY"))
+
+/**
+ *  Add a time value (using Java [ChronoUnit]) to a date
+ */
+fun Expression<*>.dateAdd(value:Long, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_ADD", this, from(value, timeUnit))
+
+/**
+ * Adds a number of days to a date.
+ */
+fun Expression<*>.dateAdd(days:Long) = MysqlDateMathFunction("DATE_ADD", this, MysqlTimeUnit(days, "DAY"))
+
+/**
+ * Return the year part of a date.
+ */
+fun Expression<*>.year() = GeneralFunctionExpression<Int>("YEAR", this)
+
+/**
+ *  Return the month from the date passed.
+ */
+fun Expression<*>.month() = GeneralFunctionExpression<Int>("MONTH", this)
+
+/**
+ * Return the day of the month part of a date.
+ */
+fun Expression<*>.day() = dayOfMonth()
+
+/**
+ * Return the day of the month part of a date.
+ */
+fun Expression<*>.dayOfMonth() = GeneralFunctionExpression<Int>("DAYOFMONTH", this)
+
+/**
+ *  Return the numeric weekday from a date (1 = Sunday, 2 = Monday, …, 7 = Saturday).
+ *  This function conforms to ODBC standard.
+ */
+fun Expression<*>.dayOfWeek() = GeneralFunctionExpression<Int>("DAYOFWEEK", this)
+
+/**
+ *  Return the numeric weekday index from a date (0 = Monday, 1 = Tuesday, … 6 = Sunday).
+ */
+fun Expression<*>.weekDay() = GeneralFunctionExpression<Int>("WEEKDAY", this)
+
+/**
+ * Return the numeric day of the year from a date.
+ */
+fun Expression<*>.dayOfYear() = GeneralFunctionExpression<Int>("DAYOFYEAR", this)
+
+/*
+ * Date Math
+ */
+
+class MysqlDateMathFunction(val name:String, val expression:Expression<*>, val interval: MysqlTimeUnit) : FunctionExpression<LocalDateTime>
+
+class MysqlTimeUnit(
+	val value:Long,
+	val unit:String
+) {
+	
+	override fun toString():String = "INTERVAL $value $unit"
+	
+	companion object {
+
+		/**
+		 * Creates a [MysqlTimeUnit] value from a Java [ChronoUnit].
+		 */
+		fun from(value:Long, timeUnit:ChronoUnit) = when (timeUnit) {
+			ChronoUnit.MICROS -> MysqlTimeUnit(value, "MICROSECOND")
+			ChronoUnit.SECONDS -> MysqlTimeUnit(value, "SECOND")
+			ChronoUnit.MINUTES -> MysqlTimeUnit(value, "MINUTE")
+			ChronoUnit.HOURS -> MysqlTimeUnit(value, "HOUR")
+			ChronoUnit.DAYS -> MysqlTimeUnit(value, "DAY")
+			ChronoUnit.MONTHS -> MysqlTimeUnit(value, "MONTH")
+			ChronoUnit.YEARS -> MysqlTimeUnit(value, "YEAR")
+			ChronoUnit.WEEKS -> MysqlTimeUnit(value, "WEEK")
+			else -> error("ChronoUnit not supported by MySQL intervals.")
+		}
+	}
+}

--- a/squash-mysql/src/org/jetbrains/squash/dialects/mysql/expressions/DateExpressions.kt
+++ b/squash-mysql/src/org/jetbrains/squash/dialects/mysql/expressions/DateExpressions.kt
@@ -3,7 +3,8 @@ package org.jetbrains.squash.dialects.mysql.expressions
 import org.jetbrains.squash.dialects.mysql.expressions.MysqlTimeUnit.Companion.from
 import org.jetbrains.squash.expressions.Expression
 import org.jetbrains.squash.expressions.FunctionExpression
-import org.jetbrains.squash.expressions.GeneralFunctionExpression
+import org.jetbrains.squash.expressions.ColumnFunctionExpression
+import org.jetbrains.squash.expressions.LiteralExpression
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -14,24 +15,16 @@ import java.time.temporal.ChronoUnit
 fun Expression<*>.date() = GeneralFunctionExpression<LocalDate>("DATE", this)
 
 /**
- *  Subtract a time value (using Java [ChronoUnit]) from a date
- */
-fun Expression<*>.dateSub(value:Long, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_SUB", this, from(value, timeUnit))
-
-/**
  * Subtracts a number of days from a date.
  */
-fun Expression<*>.dateSub(days:Long) = MysqlDateMathFunction("DATE_SUB", this, MysqlTimeUnit(days, "DAY"))
+fun Expression<*>.dateSub(expression:Expression<Number>, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_SUB", this, from(expression, timeUnit))
+fun Expression<*>.dateSub(value:Number, timeUnit:ChronoUnit = ChronoUnit.DAYS) = dateSub(LiteralExpression(value), timeUnit)
 
 /**
  *  Add a time value (using Java [ChronoUnit]) to a date
  */
-fun Expression<*>.dateAdd(value:Long, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_ADD", this, from(value, timeUnit))
-
-/**
- * Adds a number of days to a date.
- */
-fun Expression<*>.dateAdd(days:Long) = MysqlDateMathFunction("DATE_ADD", this, MysqlTimeUnit(days, "DAY"))
+fun Expression<*>.dateAdd(expression:Expression<Number>, timeUnit:ChronoUnit = ChronoUnit.DAYS) = MysqlDateMathFunction("DATE_ADD", this, from(expression, timeUnit))
+fun Expression<*>.dateAdd(value:Number, timeUnit:ChronoUnit = ChronoUnit.DAYS) = dateAdd(LiteralExpression(value), timeUnit)
 
 /**
  * Return the year part of a date.
@@ -76,7 +69,7 @@ fun Expression<*>.dayOfYear() = GeneralFunctionExpression<Int>("DAYOFYEAR", this
 class MysqlDateMathFunction(val name:String, val expression:Expression<*>, val interval: MysqlTimeUnit) : FunctionExpression<LocalDateTime>
 
 class MysqlTimeUnit(
-	val value:Long,
+	val value:Expression<Number>,
 	val unit:String
 ) {
 	
@@ -87,7 +80,7 @@ class MysqlTimeUnit(
 		/**
 		 * Creates a [MysqlTimeUnit] value from a Java [ChronoUnit].
 		 */
-		fun from(value:Long, timeUnit:ChronoUnit) = when (timeUnit) {
+		fun from(value:Expression<Number>, timeUnit:ChronoUnit) = when (timeUnit) {
 			ChronoUnit.MICROS -> MysqlTimeUnit(value, "MICROSECOND")
 			ChronoUnit.SECONDS -> MysqlTimeUnit(value, "SECOND")
 			ChronoUnit.MINUTES -> MysqlTimeUnit(value, "MINUTE")

--- a/squash-mysql/test/org/jetbrains/squash/dialects/mysql/tests/MySqlQueryTests.kt
+++ b/squash-mysql/test/org/jetbrains/squash/dialects/mysql/tests/MySqlQueryTests.kt
@@ -1,10 +1,70 @@
 package org.jetbrains.squash.dialects.mysql.tests
 
-import org.jetbrains.squash.tests.*
+import org.jetbrains.squash.dialects.mysql.expressions.*
+import org.jetbrains.squash.expressions.alias
+import org.jetbrains.squash.query.select
+import org.jetbrains.squash.results.get
+import org.jetbrains.squash.tests.DatabaseTests
+import org.jetbrains.squash.tests.QueryTests
+import org.jetbrains.squash.tests.data.AllColumnTypes
+import org.jetbrains.squash.tests.data.withAllColumnTypes
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
 
 class MySqlQueryTests : QueryTests(), DatabaseTests by MySqlDatabaseTests() {
     override fun nullsLast(sql: String): String {
         return "ISNULL(${sql.removeSuffix(" DESC")}), $sql"
     }
 
+	@Test
+	fun mysqlDatePartFunctions() = withAllColumnTypes {
+		val query = AllColumnTypes.select(
+			AllColumnTypes.datetime.year().alias("yearPart"),
+			AllColumnTypes.datetime.month().alias("monthPart"),
+			AllColumnTypes.datetime.day().alias("dayPart"),
+			AllColumnTypes.datetime.dayOfWeek().alias("dayOfWeekPart"),
+			AllColumnTypes.datetime.weekDay().alias("weekDayPart"),
+			AllColumnTypes.datetime.dayOfYear().alias("dayOfYearPart"),
+			AllColumnTypes.datetime.date().alias("dateOnly")
+		)
+		
+		connection.dialect.statementSQL(query).assertSQL {
+			"SELECT YEAR(AllColumnTypes.datetime) AS yearPart, MONTH(AllColumnTypes.datetime) AS monthPart, DAYOFMONTH(AllColumnTypes.datetime) AS dayPart, DAYOFWEEK(AllColumnTypes.datetime) AS dayOfWeekPart, WEEKDAY(AllColumnTypes.datetime) AS weekDayPart, DAYOFYEAR(AllColumnTypes.datetime) AS dayOfYearPart, DATE(AllColumnTypes.datetime) AS dateOnly FROM AllColumnTypes"
+		}
+		
+		val result = query.execute().single()
+		assertEquals(1976, result["yearPart"], "YEAR() result is incorrect")
+		assertEquals(11, result["monthPart"], "MONTH() result is incorrect")
+		assertEquals(24, result["dayPart"], "DAYOFMONTH() result is incorrect")
+		assertEquals(4, result["dayOfWeekPart"], "DAYOFWEEK() result is incorrect")
+		assertEquals(2, result["weekDayPart"], "WEEKDAY() result is incorrect")
+		assertEquals(329, result["dayOfYearPart"], "DAYOFYEAR() result is incorrect")
+	}
+
+	@Test
+	fun mysqlDateMathFunctions() = withAllColumnTypes {
+		val query = AllColumnTypes.select(
+			AllColumnTypes.datetime.alias("originalDate"),
+			
+			AllColumnTypes.date.dateSub(1).alias("minusDays"),
+			AllColumnTypes.datetime.dateSub(3, ChronoUnit.HOURS).alias("minusHours"),
+			
+			AllColumnTypes.date.dateAdd(1).alias("plusDays"),
+			AllColumnTypes.datetime.dateAdd(3, ChronoUnit.HOURS).alias("plusHours")
+		)
+
+		connection.dialect.statementSQL(query).assertSQL {
+			"SELECT AllColumnTypes.datetime AS originalDate, DATE_SUB(AllColumnTypes.`date`, INTERVAL ? DAY) AS minusDays, DATE_SUB(AllColumnTypes.datetime, INTERVAL ? HOUR) AS minusHours, DATE_ADD(AllColumnTypes.`date`, INTERVAL ? DAY) AS plusDays, DATE_ADD(AllColumnTypes.datetime, INTERVAL ? HOUR) AS plusHours FROM AllColumnTypes"
+		}
+		
+		val result = query.execute().single()
+
+		assertEquals(LocalDate.of(1976, 11, 23), result["minusDays"], "dateSub(days) result is incorrect")
+		assertEquals(LocalDateTime.of(1976, 11, 24, 5, 22), result["minusHours"], "dateSub(3, hours) result is incorrect")
+		assertEquals(LocalDate.of(1976, 11, 25), result["plusDays"], "dateAdd(days) result is incorrect")
+		assertEquals(LocalDateTime.of(1976, 11, 24, 11, 22), result["plusHours"], "dateAdd(3, hours) result is incorrect")
+	}
 }


### PR DESCRIPTION
## Note
I re-issued this pull request as improvements were made to allow Expression<Number> in dateAdd and dateSub (to use columns or literal values) in the arithmetic.

## Dependencies
This feature does require the `GeneralFunctionExpression` implementation from my previous pull request, though could be reworked easily as necessary. Merging this essentially means merging that request as well. I'm happy to resubmit this request later after the previous one is pulled if that makes the history cleaner / clearer.

## Description
Adds support for the following MySQL specific functions:
- date()
- year()
- month()
- day()
- dayOfMonth()
- dayOfWeek()
- weekDay()
- dayOfYear()
- dateAdd()
- dateSub()

Most database have very similar functions that could be quickly implemented using this as an example. This does also include a basic implementation of MySQL's `INTERVAL` syntax and values, using Java's `ChronoUnit` to generically translate. There are additional, more unique definitions for these for combined units (ex: MINUTE_SECOND), that could be added in the future as well. See: [MySQL Temporal Intervals](https://dev.mysql.com/doc/refman/5.7/en/expressions.html#temporal-intervals)